### PR TITLE
implement module singleton/service locator pattern by creating Llm Client during startup and exporting createCompletion function that cache llmClient at module level

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,7 @@ import icon from '../../resources/icon.png?asset';
 import * as dotenv from 'dotenv';
 import path from 'path';
 import { openDatabaseConnection, closeDatabaseConnection } from './database/connection';
+import { createLlmClient } from './services/llm';
 
 // Load environment variables from .env file
 dotenv.config({ path: path.resolve(process.cwd(), '.env') });
@@ -58,9 +59,11 @@ app.whenReady().then(async () => {
       optimizer.watchWindowShortcuts(window)
     })
 
+    createLlmClient();
+
     // IPC test
     ipcMain.on('ping', async () => {
-      console.log('pong')
+      console.log('pong');
     });
 
 

--- a/src/main/services/llm.ts
+++ b/src/main/services/llm.ts
@@ -1,10 +1,24 @@
 import OllamaClient from "./ollama-client";
+import { LlmClient } from "./llm_client";
+
+let llmClient: LlmClient | null = null;
 
 // Configure the OpenAI client to use Ollama
-const createLlmClient = (): LlmClient => {
-    return new OllamaClient();
+const createLlmClient = () => {
+    llmClient = new OllamaClient();
+};
+
+const createCompletion = async (prompt: string): Promise<{
+    role: string;
+    content: string;
+}> => {
+    if (!llmClient) {
+        throw new Error("LLM client not initialized. Call createLlmClient first.");
+    }
+    return await llmClient.createCompletion(prompt);
 };
 
 export {
-    createLlmClient
+    createLlmClient,
+    createCompletion
 };

--- a/src/main/services/llm_client.ts
+++ b/src/main/services/llm_client.ts
@@ -1,5 +1,5 @@
-interface LlmClient {
-    createCompletion(promtp: string): Promise<{
+export interface LlmClient {
+    createCompletion(prompt: string): Promise<{
         role: string;
         content: string;
     }>;

--- a/src/main/services/ollama-client.ts
+++ b/src/main/services/ollama-client.ts
@@ -1,6 +1,7 @@
 import OpenAI from "openai";
 import { LlmProviders, LLM_CONFIGURATIONS } from "../configuration/llm-configurations";
 import { OllamaModels } from "../configuration/llm-models";
+import { LlmClient } from "./llm_client";
 
 class OllamaClient implements LlmClient {
     private client: OpenAI;


### PR DESCRIPTION
This pull request introduces a new LLM (Large Language Model) client integration by refactoring the `llm` service, adding a new `createCompletion` function, and ensuring proper initialization of the LLM client. The most important changes include creating a shared interface for LLM clients, updating the Ollama client to implement this interface, and modifying the application entry point to initialize the LLM client.

### LLM Client Integration:

* **Added shared `LlmClient` interface**: Created a new `LlmClient` interface in `src/main/services/llm_client.ts` to standardize the implementation of LLM clients. This includes a `createCompletion` method for generating completions.

* **Updated `OllamaClient` to implement `LlmClient`**: Modified the `OllamaClient` class in `src/main/services/ollama-client.ts` to conform to the new `LlmClient` interface, ensuring compatibility with the shared structure.

### LLM Service Enhancements:

* **Refactored `createLlmClient` and added `createCompletion`**: Updated the `createLlmClient` function in `src/main/services/llm.ts` to initialize a singleton instance of the LLM client. Introduced a new `createCompletion` function to handle prompt completions, with error handling for uninitialized clients.

### Application Initialization:

* **Integrated `createLlmClient` in the app lifecycle**: Added a call to `createLlmClient` during the application's initialization in `src/main/index.ts`, ensuring the LLM client is ready when the app starts. [[1]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeR8) [[2]](diffhunk://#diff-ea37b24a27aaa2fe1e4e7545eb678f38b785089986d758bef15294f356b05faeR62-R66)